### PR TITLE
Corrected compiler flags in example CMake files.

### DIFF
--- a/cc13xx.cmake
+++ b/cc13xx.cmake
@@ -19,8 +19,8 @@ message("Linker script: ${LINKER_SCRIPT}")
 set(OBJECT_GEN_FLAGS "-mcpu=cortex-m3 ")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "C Compiler options")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "C++ Compiler options")
-set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "ASM Compiler options")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "C++ Compiler options")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "ASM Compiler options")
 
 
 # Linker flags

--- a/efr32mg.cmake
+++ b/efr32mg.cmake
@@ -23,8 +23,8 @@ message("Linker script: ${LINKER_SCRIPT}")
 set(OBJECT_GEN_FLAGS "-mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "C Compiler options")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "C++ Compiler options")
-set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "ASM Compiler options")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "C++ Compiler options")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${OBJECT_GEN_FLAGS}" CACHE INTERNAL "ASM Compiler options")
 
 # Linker flags
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -T${LINKER_SCRIPT}" CACHE INTERNAL "Linker options")


### PR DESCRIPTION
Fixes minor compiler flag issue: `CMAKE_CXX_FLAGS` and `CMAKE_ASM_FLAGS` were reset with `CMAKE_C_FLAGS` instead of toolchain `CMAKE_CXX_FLAGS`, `CMAKE_ASM_FLAGS` in the example targets. 

Thanks for sharing this toolchain, it's proved quite useful!